### PR TITLE
Enable the change of Slack API URL

### DIFF
--- a/AppFeedback/AppFeedback.h
+++ b/AppFeedback/AppFeedback.h
@@ -36,7 +36,7 @@
 + (void)configureWithSlackToken:(nonnull NSString *)token slackChannel:(nonnull NSString *)channel;
 
 /**
- Slack APi URL (default: default: https://slack.com/api)
+ Slack API URL (default: https://slack.com/api)
  */
 @property (class, nonnull) NSString *slackApiUrl;
 

--- a/AppFeedback/AppFeedback.h
+++ b/AppFeedback/AppFeedback.h
@@ -36,6 +36,11 @@
 + (void)configureWithSlackToken:(nonnull NSString *)token slackChannel:(nonnull NSString *)channel;
 
 /**
+ Slack APi URL (default: default: https://slack.com/api)
+ */
+@property (class, nonnull) NSString *slackApiUrl;
+
+/**
  List of categories to select on feedback
  */
 @property (class, nonnull) NSArray<NSString *> *feedbackCategories;

--- a/AppFeedback/AppFeedbackInternal.m
+++ b/AppFeedback/AppFeedbackInternal.m
@@ -87,6 +87,14 @@ static AppFeedback *sharedData = nil;
     [AppFeedback.shared setFeedbackCategories:feedbackCategories];
 }
 
++ (NSString *)slackApiUrl {
+    return AppFeedback.shared.config.slackApiUrl;
+}
+
++ (void)setSlackApiUrl:(NSString *)url {
+    AppFeedback.shared.config.slackApiUrl = url;
+}
+
 + (BOOL)isHidden {
     return AppFeedback.shared.isHidden;
 }

--- a/AppFeedback/Config.h
+++ b/AppFeedback/Config.h
@@ -30,6 +30,7 @@
 /// feedback カテゴリの一覧
 @property (nonatomic, strong) NSArray *categories;
 
+@property (nonatomic, strong) NSString *slackApiUrl;
 @property (nonatomic, strong) NSString *slackToken;
 @property (nonatomic, strong) NSString *slackChannel;
 

--- a/AppFeedback/Config.m
+++ b/AppFeedback/Config.m
@@ -36,11 +36,12 @@
 
 - (id)init {
     if (self = [super init]) {
-        self.categories = @[  AppFeedbackLocalizedString(@"bug", @""),
+        self.categories = @[ AppFeedbackLocalizedString(@"bug", @""),
                              AppFeedbackLocalizedString(@"request", @""),
                              AppFeedbackLocalizedString(@"question", @""),
                              AppFeedbackLocalizedString(@"design", @""),
                              AppFeedbackLocalizedString(@"others", @"")];
+        self.slackApiUrl = @"https://slack.com/api";
     }
     return self;
 }
@@ -63,6 +64,9 @@
     }
     if ([self getRequiredKey:info key:@"AppFeedback_SlackChannel"]) {
         self.slackChannel = [self getRequiredKey:info key:@"AppFeedback_SlackChannel"];
+    }
+    if ([self getRequiredKey:info key:@"AppFeedback_SlackApiUrl"]) {
+        self.slackApiUrl = [self getRequiredKey:info key:@"AppFeedback_SlackApiUrl"];
     }
 }
 

--- a/AppFeedback/ReportViewController.m
+++ b/AppFeedback/ReportViewController.m
@@ -281,7 +281,7 @@ UITextViewDelegate
     data.modelCode = DeviceUtil.ModelCode;
     data.modelName = DeviceUtil.ModelName;
 
-    SlackAPI* slackAPI = [[SlackAPI alloc] initWithToken:self.config.slackToken channel:self.config.slackChannel];
+    SlackAPI* slackAPI = [[SlackAPI alloc] initWithToken:self.config.slackToken channel:self.config.slackChannel apiUrl:self.config.slackApiUrl];
     [slackAPI postData:data
      completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
         [self enableActivityIndicator:NO];

--- a/AppFeedback/SlackAPI.h
+++ b/AppFeedback/SlackAPI.h
@@ -48,7 +48,7 @@
 
 @interface SlackAPI : NSObject
 
-- (instancetype)initWithToken:(NSString *)token channel:(NSString *)channel;
+- (instancetype)initWithToken:(NSString *)token channel:(NSString *)channel apiUrl:(NSString *)apiUrl;
 - (void)postData:(SendData *)data completionHandler:(void (^)(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 @end

--- a/AppFeedback/SlackAPI.m
+++ b/AppFeedback/SlackAPI.m
@@ -33,21 +33,24 @@
 
 @property (nonatomic, strong) NSString *token;
 @property (nonatomic, strong) NSString *channel;
+@property (nonatomic, strong) NSString *apiUrl;
 
 @end
 
 @implementation SlackAPI
 
-- (instancetype)initWithToken:(NSString *)token channel:(NSString *)channel {
+- (instancetype)initWithToken:(NSString *)token channel:(NSString *)channel apiUrl:(NSString *)apiUrl {
     if (self = [super init]) {
         self.token = token;
         self.channel = channel;
+        self.apiUrl = apiUrl;
     }
     return self;
 }
 
 - (void)postData:(SendData *)data completionHandler:(void (^)(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error))completionHandler {
-    NSString *urlString = @"https://slack.com/api/files.upload";
+
+    NSString *urlString = [NSString stringWithFormat:@"%@/files.upload", self.apiUrl];
     
     NSURL *feedbackURL = [NSURL URLWithString:urlString];
     
@@ -56,6 +59,10 @@
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:feedbackURL];
     NSString *contentType = [NSString stringWithFormat:@"multipart/form-data; boundary=%@", boundary];
     [request setValue:contentType forHTTPHeaderField:@"Content-Type"];
+
+    NSString *authHeader = [NSString stringWithFormat:@"Bearer %@", self.token];
+    [request setValue:authHeader forHTTPHeaderField:@"Authorization"];
+
     [request setHTTPMethod:@"POST"];
 
     NSString *message = [NSString stringWithFormat:
@@ -76,8 +83,7 @@
     //postデータ作成
     NSMutableData *feedbackData = [NSMutableData new];
     [self setTextData:feedbackData
-       textDictionary:@{@"token":self.token,
-                        @"channels":self.channel,
+       textDictionary:@{@"channels":self.channel,
                         @"initial_comment":message}
              boundary:boundary];
     [self setImageData:feedbackData imageData:data.imageData videoPath:data.videoPath boundary:boundary];

--- a/README.md
+++ b/README.md
@@ -152,3 +152,7 @@ Set your slack token and channel.
 List of feedback categories.
 
 The default is "Bug" "Request" "Question" "Design" "Others".
+
+#### var slackApiUrl: String { get set }
+
+Slack API URL (default: default: https://slack.com/api)

--- a/README.md
+++ b/README.md
@@ -155,4 +155,4 @@ The default is "Bug" "Request" "Question" "Design" "Others".
 
 #### var slackApiUrl: String { get set }
 
-Slack API URL (default: default: https://slack.com/api)
+Slack API URL (default: https://slack.com/api)


### PR DESCRIPTION
In order to make slack tokens more secure and less troublesome, we'll make and use a proxy API for the Slack API. Therefore, made it possible to replace the URL of the Slack API.