### PR TITLE
Don't validate slack token

### DIFF
--- a/AppFeedback/Config.m
+++ b/AppFeedback/Config.m
@@ -52,7 +52,7 @@
 }
 
 - (BOOL)isValid {
-    return self.slackToken && self.slackChannel;
+    return self.slackChannel;
 }
 
 #pragma mark - Private Methods


### PR DESCRIPTION
I changed to disable slackToken validation, because our internal slack api proxy don't need auth token.