### PR TITLE
SPM対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,10 @@ fastlane/screenshots
 
 *.framework.zip
 
+# Swift Package Manager
+
+.build
+
 # Ruby
 
 # Gemfile.lock

--- a/AppFeedback/AppFeedbackInternal.m
+++ b/AppFeedback/AppFeedbackInternal.m
@@ -70,7 +70,11 @@ static AppFeedback *sharedData = nil;
     NSString* bundlePath = [NSBundle.mainBundle pathForResource:@"AppFeedbackResource" ofType:@"bundle"];
     return [NSBundle bundleWithPath:bundlePath];
 #else
+#ifdef SWIFT_PACKAGE
+    return AppFeedback_AppFeedback_SWIFTPM_MODULE_BUNDLE();
+#else
     return [NSBundle bundleForClass:self.class];
+#endif
 #endif
 }
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "AppFeedback-ios",
+    defaultLocalization: "en",
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "AppFeedback-ios",
+            targets: ["AppFeedback-ios"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "AppFeedback-ios",
+            dependencies: []),
+        .testTarget(
+            name: "AppFeedback-iosTests",
+            dependencies: ["AppFeedback-ios"]),
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,9 @@ import PackageDescription
 let package = Package(
     name: "AppFeedback",
     defaultLocalization: "en",
+    platforms: [
+        .iOS(.v9),
+    ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
@@ -22,12 +25,18 @@ let package = Package(
         .target(
             name: "AppFeedback",
             dependencies: [],
-            path: "AppFeedback"
-            ),
+            path: "AppFeedback",
+            exclude: [
+                "Info.plist",
+            ]
+        ),
         .testTarget(
             name: "AppFeedbackTests",
             dependencies: ["AppFeedback"],
-            path: "AppFeedbackTests"
-            ),
+            path: "AppFeedbackTests",
+            exclude: [
+                "Info.plist",
+            ]
+        ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -4,13 +4,13 @@
 import PackageDescription
 
 let package = Package(
-    name: "AppFeedback-ios",
+    name: "AppFeedback",
     defaultLocalization: "en",
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
-            name: "AppFeedback-ios",
-            targets: ["AppFeedback-ios"]),
+            name: "AppFeedback",
+            targets: ["AppFeedback"]),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
@@ -20,10 +20,14 @@ let package = Package(
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
-            name: "AppFeedback-ios",
-            dependencies: []),
+            name: "AppFeedback",
+            dependencies: [],
+            path: "AppFeedback"
+            ),
         .testTarget(
-            name: "AppFeedback-iosTests",
-            dependencies: ["AppFeedback-ios"]),
+            name: "AppFeedbackTests",
+            dependencies: ["AppFeedback"],
+            path: "AppFeedbackTests"
+            ),
     ]
 )


### PR DESCRIPTION
## 概要
Swift Package Managerを使って、本ライブラリをインポート可能にするためのプルリク。
<img width="276" alt="スクリーンショット 2021-01-18 13 52 30" src="https://user-images.githubusercontent.com/19780079/104873683-6b96aa00-5994-11eb-873f-0e69d1b75fc9.png">

## インポートのやり方
- [FIle]→[Swift Packages]→[Add Package Devendency]
- https://github.com/hisakioomae/AppFeedback-ios を入力
- Branchesを選択
- `feature/spm2` を入力

## やること
- [x] Package.swift 追加
- [ ] swift build で成功するか確認
- [ ] xibファイルを開いて、`CustomView` を使用している箇所はすべて `Inherit Module From Target` にチェックを追加した
- [ ] ReadMeの変更

## 参考
https://qiita.com/kazuhiro4949/items/0378e163fa00a79eb00a