### PR TITLE
Fix CI & Add a public header for SPM

### DIFF
--- a/AppFeedback/include/AppFeedback.h
+++ b/AppFeedback/include/AppFeedback.h
@@ -1,0 +1,1 @@
+../AppFeedback.h

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -17,6 +17,7 @@ platform :ios do
     carthage(command: 'build',
              no_skip_current: true,
              platform: 'iOS',
+             use_xcframeworks: true,
              configuration: configuration)
 
     run_tests(


### PR DESCRIPTION
- Fixed CI for Xcode 12+.
- Add a public header for SPM